### PR TITLE
add:item_postsテーブルを作成

### DIFF
--- a/app/models/item_post.rb
+++ b/app/models/item_post.rb
@@ -1,0 +1,7 @@
+class ItemPost < ApplicationRecord
+  #バリデーション設定(DBに保存される前にデータが正しい形式や条件を満たしているかを「presence」や「length」で確認)
+  validates :title, presence: true, length: { maximum: 100 } #空でない、最大100文字
+  validates :body, presence: true, length: { maximum:  1000 } #空でない、最大1000文字
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :item_posts, dependent: :destroy #ユーザーが削除された時、関連するモデル（item_post）のレコード削除される
 end

--- a/db/migrate/20241206044311_create_item_posts.rb
+++ b/db/migrate/20241206044311_create_item_posts.rb
@@ -1,0 +1,11 @@
+class CreateItemPosts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :item_posts do |t|
+      t.string :title, null: false #string型（255文字まで）、null(必ずデータが入る)に設定
+      t.text :body, null: false #body型（65535文字まで）、null(必ずデータが入る)に設定
+      t.references :user, foreign_key: true #referencesで外部キーを設定、「foreign_key: true」で必ずuserテーブルのIDに存在する値でないといけないと言うルールを設定
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_01_070219) do
+ActiveRecord::Schema[7.1].define(version: 2024_12_06_044311) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "item_posts", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "body", null: false
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_item_posts_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -27,4 +36,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_01_070219) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "item_posts", "users"
 end

--- a/test/fixtures/item_posts.yml
+++ b/test/fixtures/item_posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/item_post_test.rb
+++ b/test/models/item_post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ItemPostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 概要
item_postsテーブルを作成

### 内容
app/models/item_post.rbを作成
app/models/user.rbにアソシエーションを記述
db/migrate/20241206044311_create_item_posts.rbを作成し、データベースに反映