### PR TITLE
delete:不要なマイグレーションファイルを削除

### DIFF
--- a/db/migrate/20250126071524_add_user_to_diary_events.rb
+++ b/db/migrate/20250126071524_add_user_to_diary_events.rb
@@ -1,5 +1,0 @@
-class AddUserToDiaryEvents < ActiveRecord::Migration[7.1]
-  def change
-    add_reference :diary_events, :user, null: false, foreign_key: true
-  end
-end


### PR DESCRIPTION
diary_eventsテーブルは削除したため、20250126071524_add_user_to_diary_events.rbを削除