### PR TITLE
delete:不要なマイグレーションファイルを削除

### DIFF
--- a/db/migrate/20250126103747_drop_diary_events_table.rb
+++ b/db/migrate/20250126103747_drop_diary_events_table.rb
@@ -1,5 +1,0 @@
-class DropDiaryEventsTable < ActiveRecord::Migration[7.1]
-  def up
-    drop_table :diary_events
-  end
-end


### PR DESCRIPTION
20250126103747_drop_diary_events_table.rb   