### PR TITLE
いいねしたアイテム投稿の一覧画面を実装

### DIFF
--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -8,7 +8,7 @@ class HabitPostsController < ApplicationController
   #「_habit_post.html.erb」の「habit_post.user.name」等で余計なクエリ（DBへの問い合わせ）を発行しないようにしている
   #ここでallを使ってしまうと、都度「_habit_post.html.erb」で余計なクエリが「index.html.erb」のループの回数分発行されてしまう
   def index
-    @habit_posts = HabitPost.includes(:user)
+    @habit_posts = HabitPost.includes(:user).order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/item_likes_controller.rb
+++ b/app/controllers/item_likes_controller.rb
@@ -1,13 +1,18 @@
 class ItemLikesController < ApplicationController
   def create
+    # いいねされた投稿を持ってきてitem_postに代入（どの投稿にいいねをするのかを特定するため）
     item_post = ItemPost.find(params[:item_post_id])
+    # 現在のログインユーザーが、このitem_postにいいねをする（Userモデルにあるitem_likeメソッドを使用）
     current_user.item_like(item_post)
     redirect_to item_posts_path, notice: 'いいねをしました！'
   end
     
   def destroy
+    # いいねを解除する投稿を持ってきてitem_postに代入（どの投稿のいいねを解除するのかを特定するため）
     item_post = ItemPost.find(params[:item_post_id])
+    # ログインユーザーがつけたitem_postのいいねを探す
     item_like = current_user.item_likes.find_by(item_post: item_post)
+    # もしいいねが存在すれば削除する（if文の後置）
     item_like.destroy if item_like
     redirect_to item_posts_path, notice: 'いいねを解除しました！'
   end

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -8,7 +8,7 @@ class ItemPostsController < ApplicationController
   #「_item_post.html.erb」の「item_post.user.name」等で余計なクエリ（DBへの問い合わせ）を発行しないようにしている
   #ここでallを使ってしまうと、都度「_item_post.html.erb」で余計なクエリが「index.html.erb」のループの回数分発行されてしまう
   def index
-    @item_posts = ItemPost.includes(:user)
+    @item_posts = ItemPost.includes(:user).order(created_at: :desc)
   end
   #上記は全ての（複数の）データを格納するから複数形の@item_posts、下記は１つの投稿を格納するから単数系の@item_post
 
@@ -73,6 +73,12 @@ class ItemPostsController < ApplicationController
     redirect_to item_posts_path, notice: '削除が成功しました！'
   end
   
+  # ログインしているユーザーがいいねしている投稿全てを持ってきている
+  # liked_item_postsはUserモデルでhas_manyで定義したもので「ユーザーがいいねした投稿の一覧」（詳しくはUserモデル）
+  def item_likes
+    @item_like_posts = current_user.liked_item_posts.includes(:user).order(created_at: :desc)
+  end
+
   private
 
   #ストロングパラメータは「データの保存や更新を許可するパラメータを指定して、セキュリティを強化する仕組み」

--- a/app/models/item_like.rb
+++ b/app/models/item_like.rb
@@ -2,5 +2,9 @@ class ItemLike < ApplicationRecord
   belongs_to :user
   belongs_to :item_post
 
+  # 「user_id と item_post_id の組み合わせがデータベース内で一意（ユニーク）であることを保証する」という制約
+  # 1人のユーザーが1つの投稿に対して、1回しか「いいね」できないようにするためのもの
+  # scope は、「どのカラムを基準に uniqueness を判定するか」を指定するオプション
+  # scopeで、「同じ item_post_id の中で user_id が重複しないようにする」 というルールを作っている
   validates :user_id, uniqueness: { scope: :item_post_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,17 +9,21 @@ class User < ApplicationRecord
   has_many :habit_posts, dependent: :destroy
   has_many :diaries, dependent: :destroy
   has_many :item_likes, dependent: :destroy
-  has_many :liked_item_posts, through: :item_likes, source: :item_post #ここがわからん
+  # 下記では単なる関連付け（元々のアソシエーション設定）ではなく、liked_item_postsという新たなメソッドを作るために定義している
+  # through: :item_likes で中間テーブル経由でデータを持って来れる
+  # この一行で「ユーザーがいいねした投稿の一覧」を簡単に取得できるメソッド を作っている。
+  has_many :liked_item_posts, through: :item_likes, source: :item_post
 
  #これは独自のメソッドを定義。Userモデルに書いているので、Userインスタンス（userテーブルから取り出したデータが入っているインスタンス）に対して使えるメソッド
  #resourceは引数であり、ビューファイルの「current_user_own?(item_post)」でitem_postがresourceに代入される
  #結果、own?メソッドの中で「item_post.user.id == id」という文になる
  #idはRailsが用意しているもので、現在ログインしているユーザー（current_user）を指す（本当はself.idらしいが、現時点ではよくわかってない）
-
+ #アプリのどこでも使えるが、実際にはコントローラとビューで使う（ルーティングとかでは使われない）
   def own?(resource)
     resource.user_id == id #左辺「この投稿のID」と、右辺「現在ログインしてるID」は一致してるのかを見ている
   end
 
+   #上記にも書いたように「liked_item_posts」は「ユーザーがいいねした投稿の一覧」を簡単に取得できるメソッド
   def item_like(item_post)
     liked_item_posts << item_post
   end

--- a/app/views/habit_posts/index.html.erb
+++ b/app/views/habit_posts/index.html.erb
@@ -1,6 +1,6 @@
 <!-- 確認済み -->
 <!-- 「container」でそれぞれの投稿を中央揃え（これがないと投稿の幅が伸びる）、「mx-auto」で両サイドに余白を生み出す（こればないと左寄りになる） -->
-<div class="container mx-auto my-8 text-center">
+<div class="container mx-auto my-8 text-center p-4">
   <h1 class="text-3xl font-bold mb-6 ">習慣投稿一覧</h1>
   <div class="mb-6">
     <!-- コントローラの「before_action :authenticate_user!」で、未ログイン時はログイン画面遷移している -->

--- a/app/views/item_posts/_item_like.html.erb
+++ b/app/views/item_posts/_item_like.html.erb
@@ -1,3 +1,9 @@
+<!--item_post_item_like_path(item_post)でどのURLにリクエストを送るのかを決めている-->
+<!--これによって、/item_posts/:item_post_id/item_like を受けて、ItemLikesControllerのcreateアクションが発動される-->
+<!--idは各投稿ごとに一意の名前をつけ、後にJavaScriptで操作するため？-->
+<!--turbo_methodは<a>タグをHTTPメソッドつきのリクエストに変換するためのオプション-->
+<!--data: { turbo_method: :delete }でPOSTメソッドを送るよう設定している（通常ではlink_toしか送れないから）-->
+
 <%= link_to item_post_item_like_path(item_post), id: "like-button-for-item-post-#{item_post.id}", class: "text-xl", data: { turbo_method: :post } do %>
  <i class="fa-solid fa-moon"></i><%= item_post.item_likes.count %>
 <% end %>

--- a/app/views/item_posts/_item_unlike.html.erb
+++ b/app/views/item_posts/_item_unlike.html.erb
@@ -1,3 +1,10 @@
+<!--このファイルはすでにいいねされてる状態の時に表示するファイルだから、黄色にしている-->
+<!--item_post_item_like_path(item_post)でどのURLにリクエストを送るのかを決めている-->
+<!--これによって、/item_posts/:item_post_id/item_like を受けて、ItemLikesControllerのdestroyアクションが発動される-->
+<!--idは各投稿ごとに一意の名前をつけ、後にJavaScriptで操作するため？-->
+<!--turbo_methodは<a>タグをHTTPメソッドつきのリクエストに変換するためのオプション-->
+<!--data: { turbo_method: :delete }でDELETEメソッドを送るよう設定している（通常ではlink_toしか送れないから）-->
+
 <%= link_to item_post_item_like_path(item_post), id: "unlike-button-for-item-post-#{item_post.id}", class: "text-xl text-yellow-400", data: { turbo_method: :delete } do %>
   <i class="fa-solid fa-moon"></i><%= item_post.item_likes.count %>
 <% end %>

--- a/app/views/item_posts/index.html.erb
+++ b/app/views/item_posts/index.html.erb
@@ -1,6 +1,6 @@
 <!-- 確認済み -->
 <!-- 「container」でそれぞれの投稿を中央揃え（これがないと投稿の幅が伸びる）、「mx-auto」で両サイドに余白を生み出す（こればないと左寄りになる） -->
-<div class="container mx-auto my-8 text-center">
+<div class="container mx-auto my-8 text-center p-4">
   <h1 class="text-3xl font-bold mb-6 ">アイテム投稿一覧</h1>
   <div class="mb-6">
     <!-- コントローラの「before_action :authenticate_user!」で、未ログイン時はログイン画面遷移している -->

--- a/app/views/item_posts/item_likes.html.erb
+++ b/app/views/item_posts/item_likes.html.erb
@@ -1,0 +1,10 @@
+<div class="container mx-auto my-8 text-center p-4">
+  <h1 class="text-3xl font-bold mb-6 ">いいねした投稿</h1>
+  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <% if @item_like_posts.present? %>
+      <%= render @item_like_posts %>
+    <% else %>
+      <p class="text-gray-500 text-center">いいねしたアプリはありません</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -43,7 +43,10 @@
       </div>
     </div>
     <div class="my-8">
-      <%= link_to "プロフィールを編集", edit_profile_path ,class: "bg-blue-500 text-white rounded-lg px-6 py-2 hover:bg-blue-600"%>
+      <%= link_to "プロフィールを編集", edit_profile_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-800"%>
+    </div>
+    <div class="my-8">
+      <%= link_to "【アイテム】いいねした投稿", item_likes_item_posts_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-800"%>
     </div>
   </div>
   <div class="flex justify-center max-w-xl mx-auto border-b-2 mt-16 pb-2 mb-5">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
   #get 'item_posts/new', to: 'item_posts#new' → item_posts_new_path(resourcesと異なるpath)が生成
   #post 'item_posts', to: 'item_posts#create' → item_posts_pathが生成
   resources :item_posts, only: %i[new index create show edit update destroy] do
+    collection do
+      get :item_likes
+    end
     resource :item_like, only: [:create, :destroy]
   end
   resources :habit_posts, only: %i[index new create show edit update destroy]


### PR DESCRIPTION
**概要**
いいねしたアイテム投稿の一覧画面を実装

**内容**
コメントアウトを追加
collectionを使って、ルーティングを設定
item_postコントローラにitem_likesアクションを設定
プロフィール画面より、アイテム投稿の一覧画面に遷移できるよう実装