### PR TITLE
fix:プロフィール画面を修正

### DIFF
--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -19,8 +19,12 @@
               <%= image_tag "sun.png", alt: '起床時間のアイコン'%>
              <p class="text-xs sm:text-lg">起床時間</p>
             </th>
-            <!-- strftime は、日時を好きな形式の文字列に変換するメソッド -->
-            <td class="text-xs sm:text-lg font-bold"><%= current_user.wake_up_time&.strftime('%H:%M') %></td>
+            <% if current_user.wake_up_time.present? %>
+              <!-- strftime は、日時を好きな形式の文字列に変換するメソッド -->
+              <td class="text-xs sm:text-lg font-bold"><%= current_user.wake_up_time&.strftime('%H:%M') %></td>
+            <% else %>
+              <p class="text-xs sm:text-lg">未設定</P>
+            <% end %>
           </tr>
 
           <tr class="flex flex-col items-center">
@@ -28,8 +32,12 @@
               <%= image_tag "moon.png", alt: '就寝時間のアイコン'%>
               <p class="text-xs sm:text-lg">就寝時間</p>
             </th>
+            <% if current_user.bed_time.present? %>
             <!-- strftime は、日時を好きな形式の文字列に変換するメソッド -->
-            <td class="text-xs sm:text-lg font-bold"><%= current_user.bed_time&.strftime('%H:%M') %></td>
+              <td class="text-xs sm:text-lg font-bold"><%= current_user.bed_time&.strftime('%H:%M') %></td>
+            <% else %>
+              <p class="text-xs sm:text-lg">未設定</P>
+            <% end %>
           </tr>
 
           <tr class="flex flex-col items-center">
@@ -43,10 +51,10 @@
       </div>
     </div>
     <div class="my-8">
-      <%= link_to "プロフィールを編集", edit_profile_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-800"%>
+      <%= link_to "プロフィールを編集", edit_profile_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-300"%>
     </div>
     <div class="my-8">
-      <%= link_to "【アイテム】いいねした投稿", item_likes_item_posts_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-800"%>
+      <%= link_to "【アイテム】いいねした投稿", item_likes_item_posts_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-300"%>
     </div>
   </div>
   <div class="flex justify-center max-w-xl mx-auto border-b-2 mt-16 pb-2 mb-5">
@@ -74,7 +82,7 @@
     <% end %>
   </div>
   <div class ="my-8">
-    <%= link_to "日記を書く", new_diary_path ,class: "bg-blue-500 text-white rounded-lg px-6 py-2 hover:bg-blue-600"%>
+    <%= link_to "日記を書く", new_diary_path ,class: "bg-sky-100 rounded-lg px-6 py-2 hover:bg-sky-300"%>
   </div>
 </div>    
 


### PR DESCRIPTION
**概要**
いいねしたアイテム投稿の一覧画面を実装

**内容**
コメントアウトを追加
collectionを使って、ルーティングを設定
item_postコントローラにitem_likesアクションを設定
プロフィール画面より、アイテム投稿の一覧画面に遷移できるよう実装