### PR TITLE
fix:フォーム投稿エラー時のレイアウト崩れを修正

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ module Myapp
     config.time_zone = 'Tokyo'
     # デフォルトのロケールを日本語に設定
     config.i18n.default_locale = :ja
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
+    
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }を記載
