### PR TITLE
アイテム投稿のページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,8 @@ gem 'rails-i18n'
 
 gem 'devise-i18n'
 
+gem 'kaminari'
+
 #dotenv-rails を 開発環境 と テスト環境 でのみ有効にする（本番環境では不要なので有効にしない（セキュリティ対策）。）
 gem 'dotenv-rails', groups: [:development, :test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,18 @@ GEM
       activesupport (>= 5.0.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     logger (1.6.1)
     loofah (2.23.1)
       crass (~> 1.0.2)
@@ -334,6 +346,7 @@ DEPENDENCIES
   fog-aws
   jbuilder
   jsbundling-rails
+  kaminari
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3)

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -8,7 +8,7 @@ class ItemPostsController < ApplicationController
   #「_item_post.html.erb」の「item_post.user.name」等で余計なクエリ（DBへの問い合わせ）を発行しないようにしている
   #ここでallを使ってしまうと、都度「_item_post.html.erb」で余計なクエリが「index.html.erb」のループの回数分発行されてしまう
   def index
-    @item_posts = ItemPost.includes(:user).order(created_at: :desc)
+    @item_posts = ItemPost.includes(:user).order(created_at: :desc).page(params[:page]).per(20)
   end
   #上記は全ての（複数の）データを格納するから複数形の@item_posts、下記は１つの投稿を格納するから単数系の@item_post
 

--- a/app/models/habit_post.rb
+++ b/app/models/habit_post.rb
@@ -2,7 +2,7 @@ class HabitPost < ApplicationRecord
   #バリデーション設定(DBに保存される前にデータが正しい形式や条件を満たしているかを「presence」や「length」で確認)
   validates :title, presence: true, length: { maximum: 100 } #空でない、最大100文字
   validates :body, presence: true, length: { maximum: 1000 } #空でない、最大1000文字
-  validates :habit_post_image, presence: true
+  validates :habit_post_image, presence: true, if: -> { Rails.env.production? } # 本番環境のみ必須
 
   belongs_to :user
   has_many :habit_likes, dependent: :destroy

--- a/app/views/item_posts/index.html.erb
+++ b/app/views/item_posts/index.html.erb
@@ -49,6 +49,7 @@
       <%= render @item_posts %>
 
     </div>
+    <%= paginate @item_posts, window: 2, outer_window: 1 %>
   <% else %>
     <p class="text-gray-500 text-center">投稿がまだありません。</p>
   <% end %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "First" page
+  - available local variables
+    url:           url to the first page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="first">
+  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,8 @@
+<%# Non-link tag that stands for skipped pages...
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Last" page
+  - available local variables
+    url:           url to the last page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="last">
+  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
+</span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Next" page
+  - available local variables
+    url:           url to the next page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="next">
+  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, class: "join-item btn", rel: 'next', remote: true %>
+</span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,10 @@
+<%# Link showing page number
+  - available local variables
+    page:          a page object for "this" page
+    url:           url to this page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<%= link_to page, url, class: "join-item btn #{'btn-active' if page.current?}", remote: true, rel: page.rel %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,25 @@
+<%# The container tag
+  - available local variables
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+    paginator:     the paginator that renders the pagination tags inside
+-%>
+<div class="container mx-auto my-8 text-center p-4">
+  <%= paginator.render do -%>
+    <nav class="pagination" role="navigation" aria-label="pager">
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| -%>
+        <% if page.display_tag? -%>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? %>
+          <%= gap_tag %>
+        <% end -%>
+      <% end -%>
+      <% unless current_page.out_of_range? %>
+        <%= next_page_tag unless current_page.last? %>
+      <% end %>
+    </nav>
+  <% end -%>
+</div>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,11 @@
+<%# Link to the "Previous" page
+  - available local variables
+    url:           url to the previous page
+    current_page:  a page object for the currently displayed page
+    total_pages:   total number of pages
+    per_page:      number of items to fetch per page
+    remote:        data-remote
+-%>
+<span class="prev">
+  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, class: "join-item btn", rel: 'prev', remote: remote %>
+</span>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 5
+  # config.max_per_page = nil
+  config.window = 2
+  config.outer_window = 1
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  views:
+    pagination:
+      previous: "前へ"
+      next: "次へ"
+      truncate: "•••"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -22,7 +22,7 @@ User.delete_all
     )
   
     # 各ユーザーにランダムなアイテム投稿を3件作成
-    3.times do
+    20.times do
       user.item_posts.create!(
         title: Faker::Lorem.sentence(word_count: 3),
         body: Faker::Lorem.paragraph(sentence_count: 5)
@@ -30,7 +30,7 @@ User.delete_all
     end
 
     # 各ユーザーにランダムな習慣投稿を3件作成
-    3.times do
+    20.times do
       user.habit_posts.create!(
         title: Faker::Lorem.sentence(word_count: 3),
         body: Faker::Lorem.paragraph(sentence_count: 5)


### PR DESCRIPTION
・「gem 'kaminari'」を導入
・「.page(params[:page]).per(20)」で20ページごとにデータを分割
・前後２ページを表示
・ページ番号が省略された箇所に「…」を表示
・一番外側のwindowは1に設定
・ダミーデータを増加