### PR TITLE
未ログインユーザーでも投稿の詳細画面を閲覧できるよう修正

### DIFF
--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -1,6 +1,6 @@
 class HabitPostsController < ApplicationController
   #Deviseを導入したために使えるようになったメソッドで、ユーザーがログインしているかを判別し、未ログイン時には、自動的にログインページにリダイレクトさせる
-  before_action :authenticate_user!, only: [:new, :create, :edit, :show, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   #set_habit_postで[:edit, :update, :destroy]アクションの前に、「投稿が削除されておらず存在するかどうか、また、アクセス権限があるか（人の投稿でないか）」を確認している
   before_action :set_habit_post, only: [:edit, :update, :destroy]
 

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -1,6 +1,6 @@
 class ItemPostsController < ApplicationController
   #Deviseを導入したために使えるようになったメソッドで、ユーザーがログインしているかを判別し、未ログイン時には、自動的にログインページにリダイレクトさせる
-  before_action :authenticate_user!, only: [:new, :create, :edit, :show, :update, :destroy]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
   #set_habit_postで[:edit, :update, :destroy]アクションの前に、「投稿が削除されておらず存在するかどうか、また、アクセス権限があるか（人の投稿でないか）」を確認している
   before_action :set_item_post, only: [:edit, :update, :destroy]
   

--- a/app/views/habit_comments/_habit_comment.html.erb
+++ b/app/views/habit_comments/_habit_comment.html.erb
@@ -29,7 +29,7 @@
 
   <!--メッセージの下の部分について（削除ボタン）-->
   <div class="chat-footer">
-    <% if current_user.own?(habit_comment) %>
+    <% if current_user&.own?(habit_comment) %>
       <%= link_to '削除', habit_comment_path(habit_comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-blue-500 hover:underline text-xs mt-1 block' %>
     <% end %>
   </div>

--- a/app/views/habit_posts/show.html.erb
+++ b/app/views/habit_posts/show.html.erb
@@ -33,7 +33,7 @@
 
     <div class = "flex flex-row gap-7" >
       <!-- 現在ログインしているユーザーと投稿しているユーザーが等しい時、表示される -->
-      <% if current_user.own?(@habit_post) %> 
+      <% if current_user&.own?(@habit_post) %> 
         <!-- 投稿編集 -->
         <%= link_to edit_habit_post_path, data: { turbo: false } do %>
           <i class="fa-solid fa-pencil align-middle"></i>

--- a/app/views/item_comments/_item_comment.html.erb
+++ b/app/views/item_comments/_item_comment.html.erb
@@ -29,7 +29,7 @@
 
   <!--メッセージの下の部分について（削除ボタン）-->
   <div class="chat-footer">
-    <% if current_user.own?(item_comment) %>
+    <% if current_user&.own?(item_comment) %>
       <%= link_to '削除', item_comment_path(item_comment), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-blue-500 hover:underline text-xs mt-1 block' %>
     <% end %>
   </div>

--- a/app/views/item_posts/show.html.erb
+++ b/app/views/item_posts/show.html.erb
@@ -35,7 +35,7 @@
   
     <!-- 現在ログインしているユーザーと投稿しているユーザーが等しい時、表示される -->
     <div class = "flex flex-row gap-7" >
-      <% if current_user.own?(@item_post) %> 
+      <% if current_user&.own?(@item_post) %> 
         <!-- 投稿編集 -->
         <%= link_to edit_item_post_path, data: { turbo: false } do %>
           <i class="fa-solid fa-pencil align-middle"></i>


### PR DESCRIPTION
**概要**
未ログインユーザーでも投稿の詳細画面を閲覧できるよう修正
（詳細画面をSNSでOGPを用いて表示するとき、未ログインでも表示されるように実装）

**内容**
・:authenticate_user!　のshowアクションを削除
・該当箇所にボッチ演算子を用いて、current_userがnilの場合は、nilを返すよう実装
