### PR TITLE
画面幅が小さい時、検索フォームの周りに余白を設定

### DIFF
--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -2,9 +2,11 @@
 <!-- qはコントローラで作った検索の条件（ワード）が入ったオブジェクト -->
 <!-- urlは検索後に遷移するurl先（item_postコントローラのindexアクション）を指定 -->
 <!-- title_or_body_contはRansackで使えるようになったもので、「タイトル or 本文 に「◯◯」が含まれる投稿を探す」と言う意味で内部でSQLが作られ実行される -->
-<%= search_form_for q, url: url do |f| %>
-  <div class="max-w-xl flex flex-row items-center space-x-2">
-    <%= f.search_field :title_or_body_cont, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
-    <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
-  </div>
-<% end %>
+<div class = "max-w-sm p-4">
+  <%= search_form_for q, url: url do |f| %>
+    <div class="max-w-xl flex flex-row items-center space-x-2">
+      <%= f.search_field :title_or_body_cont, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
+      <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
app/views/shared/_search_form.html.erbに<div class = "max-w-sm p-4">
を実装