### PR TITLE
オートコンプリート機能の実装（投稿のタイトルのみ）

### DIFF
--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -74,7 +74,7 @@ class HabitPostsController < ApplicationController
   end
 
   def search
-    @habit_posts = HabitPost.where("title like ?", "%#{params[:q]}%")
+    @habit_posts = HabitPost.where("title like ?", "%#{params[:q]}%").limit(5)
     render partial: "search"
   end
 

--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -73,6 +73,11 @@ class HabitPostsController < ApplicationController
     @habit_post_ranking = HabitPost.find(HabitLike.group(:habit_post_id).order('count(id) desc').limit(5).pluck(:habit_post_id))
   end
 
+  def search
+    @habit_posts = HabitPost.where("title like ?", "%#{params[:q]}%")
+    render partial: "search"
+  end
+
   private
 
   def habit_post_params

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -99,6 +99,7 @@ class ItemPostsController < ApplicationController
     @item_posts = ItemPost.where("title like ?", "%#{params[:q]}%")
     render partial: "search"
   end
+
   private
 
   #ストロングパラメータは「データの保存や更新を許可するパラメータを指定して、セキュリティを強化する仕組み」

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -96,7 +96,7 @@ class ItemPostsController < ApplicationController
   end
 
   def search
-    @item_posts = ItemPost.where("title like ?", "%#{params[:q]}%")
+    @item_posts = ItemPost.where("title like ?", "%#{params[:q]}%").limit(5)
     render partial: "search"
   end
 

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -95,6 +95,10 @@ class ItemPostsController < ApplicationController
     @item_post_ranking = ItemPost.find(ItemLike.group(:item_post_id).order('count(id) desc').limit(5).pluck(:item_post_id))
   end
 
+  def search
+    @item_posts = ItemPost.where("title like ?", "%#{params[:q]}%")
+    render partial: "search"
+  end
   private
 
   #ストロングパラメータは「データの保存や更新を許可するパラメータを指定して、セキュリティを強化する仕組み」

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,14 @@
 import { Application } from "@hotwired/stimulus"
 
+// autocomplete実装時に追加
+import { Autocomplete } from 'stimulus-autocomplete'
 const application = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
 window.Stimulus   = application
+
+// autocomplete実装時に追加
+application.register('autocomplete', Autocomplete)
 
 export { application }

--- a/app/views/habit_posts/_search.html.erb
+++ b/app/views/habit_posts/_search.html.erb
@@ -1,0 +1,5 @@
+<% @habit_posts.each do |habit_post| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= habit_post.id %>" data-autocomplete-label="<%= habit_post.title %>">
+    <%= habit_post.title %>
+  </li>
+<% end %>

--- a/app/views/item_posts/_search.html.erb
+++ b/app/views/item_posts/_search.html.erb
@@ -1,0 +1,5 @@
+<% @item_posts.each do |item_post| %>
+  <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= item_post.id %>" data-autocomplete-label="<%= item_post.title %>">
+    <%= item_post.title %>
+  </li>
+<% end %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -2,11 +2,17 @@
 <!-- qはコントローラで作った検索の条件（ワード）が入ったオブジェクト -->
 <!-- urlは検索後に遷移するurl先（item_postコントローラのindexアクション）を指定 -->
 <!-- title_or_body_contはRansackで使えるようになったもので、「タイトル or 本文 に「◯◯」が含まれる投稿を探す」と言う意味で内部でSQLが作られ実行される -->
-<div class = "max-w-sm p-4">
+<div class = "relative max-w-sm p-4">
   <%= search_form_for q, url: url do |f| %>
-    <div class="max-w-xl flex flex-row items-center space-x-2">
-      <%= f.search_field :title_or_body_cont, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
-      <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+    <!-- 【消す】最初に書いたやつ、URLのパラメータによって変えている（勉強する）<div data-controller="autocomplete" data-autocomplete-url-value="/item_posts/search" role="combobox"> -->
+    <% url_value = params[:type] == 'habit' ? '/habit_posts/search' : '/item_posts/search' %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="<%= url_value %>" role="combobox">
+      <div class="max-w-xl flex flex-row items-center space-x-2">
+        <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
+        <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+        <ul class="list-group absolute top-full z-10 bg-base-200 hover:bg-base-300 w-full md:text-sm" data-autocomplete-target="results"></ul>
+        <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
     collection do
       get :ranking
     end
+    collection do
+      get :search
+    end
     resources :habit_likes, only: %i[create destroy]
     resources :habit_comments, only: %i[create destroy], shallow: true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
     collection do
       get :ranking
     end
+    collection do
+      get :search
+    end
     resources :item_likes, only: %i[create destroy] 
     resources :item_comments, only: %i[create destroy], shallow: true
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     resources :item_likes, only: %i[create destroy] 
     resources :item_comments, only: %i[create destroy], shallow: true
   end
+
   resources :habit_posts, only: %i[index new create show edit update destroy] do
     collection do
       get :habit_likes

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "autoprefixer": "^10.4.20",
     "daisyui": "^4.12.14",
     "postcss": "^8.4.49",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwindcss": "^3.4.17"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -839,6 +839,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
【概要】
オートコンプリート機能の実装（投稿のタイトルのみ）

【内容】
・「yarn add stimulus-autocomplete」でstimulus-autocompleteを追加
・「app/javascript/controllers/application.js」にtimulus-autocompleteの設定を追加
・ルーティングにcollectionによりsearchアクションを追加
・コントローラで候補を５件表示
・自動補完部分の「app/views/item_posts/_search.html.erb」を作成
・「app/views/shared/_search_form.html.erb」にオートコンプリートを紐付け