### PR TITLE
fix:_searchform.html.erbを修正

### DIFF
--- a/app/views/habit_posts/_search_form.html.erb
+++ b/app/views/habit_posts/_search_form.html.erb
@@ -1,0 +1,16 @@
+<!-- search_form_forは、Ransackで使えるようになったフォーム -->
+<!-- qはコントローラで作った検索の条件（ワード）が入ったオブジェクト -->
+<!-- urlは検索後に遷移するurl先（item_postコントローラのindexアクション）を指定 -->
+<!-- title_or_body_contはRansackで使えるようになったもので、「タイトル or 本文 に「◯◯」が含まれる投稿を探す」と言う意味で内部でSQLが作られ実行される -->
+<div class = "relative max-w-sm p-4">
+  <%= search_form_for q, url: url do |f| %>
+    <div data-controller="autocomplete" data-autocomplete-url-value="/habit_posts/search" role="combobox">
+      <div class="max-w-xl flex flex-row items-center space-x-2">
+        <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
+        <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+        <ul class="list-group absolute top-full z-10 bg-base-200 hover:bg-base-300 w-full md:text-sm" data-autocomplete-target="results"></ul>
+        <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/habit_posts/habit_likes.html.erb
+++ b/app/views/habit_posts/habit_likes.html.erb
@@ -2,7 +2,7 @@
 <div class="container mx-auto my-8 text-center p-4">
   <h1 class="text-3xl font-bold mb-6 ">いいねした投稿</h1>
   <div class = "flex justify-center my-12">
-    <%= render 'shared/search_form', q: @q, url: habit_likes_habit_posts_path %>
+    <%= render 'search_form', q: @q, url: habit_likes_habit_posts_path %>
   </div>
   <% if @habit_like_posts.present? %>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">

--- a/app/views/habit_posts/index.html.erb
+++ b/app/views/habit_posts/index.html.erb
@@ -5,7 +5,7 @@
   <h1 class="text-3xl font-bold mb-6 ">習慣投稿一覧</h1>
   <!-- パーシャル先では「@q」をq、「item_posts_path」をurlとして使う -->
   <div class = "flex justify-center my-12">
-    <%= render 'shared/search_form', q: @q, url: habit_posts_path %>
+    <%= render 'search_form', q: @q, url: habit_posts_path %>
   </div>
   <div class="my-6">
     <!-- コントローラの「before_action :authenticate_user!」で、未ログイン時はログイン画面遷移している -->

--- a/app/views/item_posts/_search_form.html.erb
+++ b/app/views/item_posts/_search_form.html.erb
@@ -4,9 +4,7 @@
 <!-- title_or_body_contはRansackで使えるようになったもので、「タイトル or 本文 に「◯◯」が含まれる投稿を探す」と言う意味で内部でSQLが作られ実行される -->
 <div class = "relative max-w-sm p-4">
   <%= search_form_for q, url: url do |f| %>
-    <!-- 【消す】最初に書いたやつ、URLのパラメータによって変えている（勉強する）<div data-controller="autocomplete" data-autocomplete-url-value="/item_posts/search" role="combobox"> -->
-    <% url_value = params[:type] == 'habit' ? '/habit_posts/search' : '/item_posts/search' %>
-    <div data-controller="autocomplete" data-autocomplete-url-value="<%= url_value %>" role="combobox">
+    <div data-controller="autocomplete" data-autocomplete-url-value="/item_posts/search" role="combobox">
       <div class="max-w-xl flex flex-row items-center space-x-2">
         <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
         <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>

--- a/app/views/item_posts/index.html.erb
+++ b/app/views/item_posts/index.html.erb
@@ -5,7 +5,7 @@
   <h1 class="text-3xl font-bold mb-6 ">アイテム投稿一覧</h1>
   <!-- パーシャル先では「@q」をq、「item_posts_path」をurlとして使う -->
   <div class = "flex justify-center my-12">
-    <%= render 'shared/search_form', q: @q, url: item_posts_path %>
+    <%= render 'search_form', q: @q, url: item_posts_path %>
   </div>
   <div class="my-6">
     <!-- コントローラの「before_action :authenticate_user!」で、未ログイン時はログイン画面遷移している -->

--- a/app/views/item_posts/item_likes.html.erb
+++ b/app/views/item_posts/item_likes.html.erb
@@ -2,7 +2,7 @@
 <div class="container mx-auto my-8 text-center p-4">
   <h1 class="text-3xl font-bold mb-6 ">いいねした投稿</h1>
   <div class = "flex justify-center my-12">
-    <%= render 'shared/search_form', q: @q, url: item_likes_item_posts_path %>
+    <%= render 'search_form', q: @q, url: item_likes_item_posts_path %>
   </div>
   <% if @item_like_posts.present? %>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">


### PR DESCRIPTION
【概要】
fix:_searchform.html.erbを修正

【内容】
・shared配下にあった、_searchform.html.erbをitem_postsとhabit_postsの配下にそれぞれ移動
・習慣一覧での検索でも、入力時に候補が出るよう実装