### PR TITLE
マルチ検索機能を実装

### DIFF
--- a/app/models/habit_post.rb
+++ b/app/models/habit_post.rb
@@ -10,7 +10,7 @@ class HabitPost < ApplicationRecord
   has_many :habit_comments, dependent: :destroy
 
   def self.ransackable_attributes(auth_object = nil)
-    ["title","body"]
+    ["title","body","habit_tag_id"]
   end
   
   # アソシエーションで関連づいているモデルでどのモデルを検索対象にしているかを設定している（今回はなし

--- a/app/models/item_post.rb
+++ b/app/models/item_post.rb
@@ -10,7 +10,7 @@ class ItemPost < ApplicationRecord
 
   # どのカラムを検索対象にして許可するかを設定している
   def self.ransackable_attributes(auth_object = nil)
-    ["title","body"]
+    ["title","body","item_tag_id"]
   end
   
   # アソシエーションで関連づいているモデルでどのモデルを検索対象にしているかを設定している（今回はなし

--- a/app/views/habit_posts/_search_form.html.erb
+++ b/app/views/habit_posts/_search_form.html.erb
@@ -14,8 +14,9 @@
           <ul class="list-group absolute top-full z-10 bg-base-200 hover:bg-base-300 w-60 md:text-sm" data-autocomplete-target="results"></ul>
         </div>
 
+        <!-- |tag| [tag.name, tag.id] で、tag.nameで表示するもの、tag.idはサーバーに送るもの-->
         <div class="flex flex-col my-2">
-          <%= f.label :select, "カテゴリー", class: "text-lg font-medium text-gray-700" %> 
+          <%= f.label :habit_tag_id_eq, "カテゴリー", class: "text-lg font-medium text-gray-700" %> 
           <%= f.select :habit_tag_id_eq, HabitTag.all.map { |tag| [tag.name, tag.id] }, { include_blank: "未選択" }, class: "w-80 md:w-60 rounded-lg p-2 border border-gray-300" %>
         </div>
 

--- a/app/views/habit_posts/_search_form.html.erb
+++ b/app/views/habit_posts/_search_form.html.erb
@@ -4,12 +4,24 @@
 <!-- title_or_body_contはRansackで使えるようになったもので、「タイトル or 本文 に「◯◯」が含まれる投稿を探す」と言う意味で内部でSQLが作られ実行される -->
 <div class = "relative max-w-sm">
   <%= search_form_for q, url: url do |f| %>
+
     <div data-controller="autocomplete" data-autocomplete-url-value="/habit_posts/search" role="combobox">
-      <div class="max-w-xl flex flex-row items-center space-x-2">
-        <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
-        <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
-        <ul class="list-group absolute top-full z-10 bg-base-200 hover:bg-base-300 w-60 md:text-sm" data-autocomplete-target="results"></ul>
-        <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+      <div class="max-w-xl flex flex-col md:flex-row items-center md:items-end justify-center space-x-2">
+        <div class="flex flex-col relative my-2">
+          <%= f.label :search_fiel, "習慣・本文", class: "text-lg font-medium text-gray-700" %>
+          <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 md:w-60 rounded-lg p-2 border border-gray-300", placeholder: 'キーワードを入力' %>
+          <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+          <ul class="list-group absolute top-full z-10 bg-base-200 hover:bg-base-300 w-60 md:text-sm" data-autocomplete-target="results"></ul>
+        </div>
+
+        <div class="flex flex-col my-2">
+          <%= f.label :select, "カテゴリー", class: "text-lg font-medium text-gray-700" %> 
+          <%= f.select :habit_tag_id_eq, HabitTag.all.map { |tag| [tag.name, tag.id] }, { include_blank: "未選択" }, class: "w-80 md:w-60 rounded-lg p-2 border border-gray-300" %>
+        </div>
+
+        <div class="my-2">
+          <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/item_posts/_search_form.html.erb
+++ b/app/views/item_posts/_search_form.html.erb
@@ -7,17 +7,25 @@
 
     <!-- data-controller="autocomplete":ここをオートコンプリートの対象にするという合図 -->
     <div data-controller="autocomplete" data-autocomplete-url-value="/item_posts/search" role="combobox">
-      <div class="max-w-xl flex flex-row items-center space-x-2">
+      <div class="max-w-xl flex flex-col md:flex-row items-center md:items-end justify-center space-x-2 ">
+        <div class="flex flex-col relative my-2">
+          <!-- data-autocomplete-url-value="/item_posts/search":入力されるたびに送信されるリクエスト先を指定 -->
+          <%= f.label :search_fiel, "アイテム名・本文", class: "text-lg font-medium text-gray-700" %>
+          <!-- data: { autocomplete_target: 'input' },:このフォームに文字が入力されたらオートコンプリートを開始して！ とstimulusに伝えている-->
+          <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 md:w-60 rounded-lg p-2 border border-gray-300", placeholder: 'キーワードを入力' %><!-- data: { autocomplete_target: 'input' },:このフォームに文字が入力されたらオートコンプリートを開始して！ とstimulusに伝えている-->
+          <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+          <!-- data-autocomplete-target="results": レスポンスで帰ってきた<li>タグを表示している-->
+          <ul class="list-group absolute  top-full z-10 bg-base-200 hover:bg-base-300 w-60 md:text-sm" data-autocomplete-target="results"></ul>
+        </div>
 
-        <!-- data-autocomplete-url-value="/item_posts/search":入力されるたびに送信されるリクエスト先を指定 -->
-        <%= f.search_field :title_or_body_cont, data: { autocomplete_target: 'input' }, class: "w-80 rounded-lg p-2 border border-gray-300", placeholder: 'アイテム名、本文を検索' %>
-        
-        <!-- data: { autocomplete_target: 'input' },:このフォームに文字が入力されたらオートコンプリートを開始して！ とstimulusに伝えている-->
-        <%= f.hidden_field :title, data: { autocomplete_target: 'hidden' } %>
+        <div class="flex flex-col my-2">
+          <%= f.label :select, "カテゴリー", class: "text-lg font-medium text-gray-700" %> 
+          <%= f.select :item_tag_id_eq, ItemTag.all.map { |tag| [tag.name, tag.id] }, { include_blank: "未選択" }, class: "w-80 md:w-60 rounded-lg p-2 border border-gray-300" %>
+        </div>
 
-        <!-- data-autocomplete-target="results": レスポンスで帰ってきた<li>タグを表示している-->
-        <ul class="list-group absolute top-full z-10 bg-base-200 hover:bg-base-300 w-60 md:text-sm" data-autocomplete-target="results"></ul>
-        <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+        <div class="my-2">
+          <%= f.submit '検索', class: "bg-gray-300 rounded-lg px-6 py-2 hover:bg-gray-500 shadow-xl" %>
+        </div>
       </div>
     </div>
   <% end %>

--- a/app/views/item_posts/_search_form.html.erb
+++ b/app/views/item_posts/_search_form.html.erb
@@ -19,7 +19,7 @@
         </div>
 
         <div class="flex flex-col my-2">
-          <%= f.label :select, "カテゴリー", class: "text-lg font-medium text-gray-700" %> 
+          <%= f.label :item_tag_id_eq, "カテゴリー", class: "text-lg font-medium text-gray-700" %> 
           <%= f.select :item_tag_id_eq, ItemTag.all.map { |tag| [tag.name, tag.id] }, { include_blank: "未選択" }, class: "w-80 md:w-60 rounded-lg p-2 border border-gray-300" %>
         </div>
 

--- a/app/views/item_posts/_search_form.html.erb
+++ b/app/views/item_posts/_search_form.html.erb
@@ -7,7 +7,7 @@
 
     <!-- data-controller="autocomplete":ここをオートコンプリートの対象にするという合図 -->
     <div data-controller="autocomplete" data-autocomplete-url-value="/item_posts/search" role="combobox">
-      <div class="max-w-xl flex flex-col md:flex-row items-center md:items-end justify-center space-x-2 ">
+      <div class="max-w-xl flex flex-col md:flex-row items-center md:items-end justify-center space-x-2">
         <div class="flex flex-col relative my-2">
           <!-- data-autocomplete-url-value="/item_posts/search":入力されるたびに送信されるリクエスト先を指定 -->
           <%= f.label :search_fiel, "アイテム名・本文", class: "text-lg font-medium text-gray-700" %>


### PR DESCRIPTION
**概要**
マルチ検索機能を実装

**内容**
・app/models/item_post.rb(habit_post.rb)に、item_tag_id(habit_tag_id)を追記（検索対象のカラムの追加）
・app/views/item_posts(habit_posts)/_search_form.html.erbに、カテゴリーの検索窓を追加


close #93