### PR TITLE
各投稿のクリックすると詳細画面に遷移できるよう実装

### DIFF
--- a/app/views/habit_posts/_habit_post.html.erb
+++ b/app/views/habit_posts/_habit_post.html.erb
@@ -1,23 +1,25 @@
-<div class="relative bg-gray-50 p-4 border rounded-lg shadow hover:border-gray-400 transition-300 cursor-pointer">
-  <%= link_to habit_post_path(habit_post) do %>
-    <div class= "absolute top-4 left-4 flex flex-row gap-4">
-      <%= image_tag habit_post.user.avatar.url , class:"w-8 h-8 rounded-full border border-gray-200" %>
-      <p class="text-md text-gray-800"><%= habit_post.user.name %></p>  <%# ここで余計なクエリが発行されないよう、indexアクションでincludesを使ってN+1問題を回避している %>
-    </div>
-    <div class= "absolute top-4 right-4">
-      <p class="text-md text-gray-800"><%= habit_post.created_at.strftime("%y/%m/%d %H:%M:%S") %></h1>
-    </div>
+<div class="relative bg-gray-50 p-4 border rounded-lg shadow transition-transform duration-300 hover:scale-105"
+     data-url="<%= habit_post_path(habit_post) %>" 
+     onclick="location.href='<%= habit_post_path(habit_post) %>';">
 
-    <!-- 選択した画像がある場合には表示 -->
-    <div class="flex justify-center mt-12">
-      <% if habit_post.habit_post_image.present? %>
-        <%= image_tag habit_post.habit_post_image, class: "w-72 h-48 object-cover", alt: "Habit post image"%><!-- object-coverで余白を埋める-->
-      <% else %>
-        <div class="w-72 h-48 bg-gray-200"></div>
-      <% end %>
-    </div>
-  <% end %>
-  <%= link_to habit_post.title, habit_post_path(habit_post), class: 'text-2xl font-bold text-gray-800 hover:bg-gray-300' %>
+  <div class= "absolute top-4 left-4 flex flex-row gap-4">
+    <%= image_tag habit_post.user.avatar.url , class:"w-8 h-8 rounded-full border border-gray-200" %>
+    <p class="text-md text-gray-800"><%= habit_post.user.name %></p>  <%# ここで余計なクエリが発行されないよう、indexアクションでincludesを使ってN+1問題を回避している %>
+  </div>
+  <div class= "absolute top-4 right-4">
+    <p class="text-md text-gray-800"><%= habit_post.created_at.strftime("%y/%m/%d %H:%M:%S") %></p>
+  </div>
+
+  <!-- 選択した画像がある場合には表示 -->
+  <div class="flex justify-center mt-12">
+    <% if habit_post.habit_post_image.present? %>
+      <%= image_tag habit_post.habit_post_image, class: "rounded-lg w-72 h-48 object-cover", alt: "Habit post image"%><!-- object-coverで余白を埋める-->
+    <% else %>
+      <div class="w-72 h-48 bg-gray-200"></div>
+    <% end %>
+  </div>
+
+  <h1 class = 'text-2xl font-bold'><%= habit_post.title %></h1>
 
   <p class="text-sm text-gray-500 m-8"><%= habit_post.body.truncate(100) %></p>
   <div class="absolute bottom-5 left-4 flex items-center gap-6">

--- a/app/views/habit_posts/show.html.erb
+++ b/app/views/habit_posts/show.html.erb
@@ -15,7 +15,7 @@
 
     <div class ="flex flex-col gap-6">
       <% if @habit_post.habit_post_image.present? %>
-        <%= image_tag @habit_post.habit_post_image, alt: "Habit post image" %>
+        <%= image_tag @habit_post.habit_post_image, class: "rounded-lg", alt: "Habit post image" %>
       <% end %>
     </div>
 

--- a/app/views/item_posts/_item_post.html.erb
+++ b/app/views/item_posts/_item_post.html.erb
@@ -19,7 +19,7 @@
     <% end %>
   </div>
  
-  <h2 class = 'text-2xl font-bold'><%= item_post.title %></h2>
+  <h1 class = 'text-2xl font-bold'><%= item_post.title %></h1>
 
   <p class="text-sm text-gray-500 m-8"><%= item_post.body.truncate(100) %></p>
   <div class="absolute bottom-5 left-4 flex items-center gap-6">

--- a/app/views/item_posts/_item_post.html.erb
+++ b/app/views/item_posts/_item_post.html.erb
@@ -1,23 +1,25 @@
-<div class=" relative bg-gray-50 p-4 border rounded-lg shadow hover:border-gray-400 transition-300 cursor-pointer">
-  <%= link_to item_post_path(item_post) do %>
-    <div class= "absolute top-4 left-4 flex flex-row gap-4">
-      <%= image_tag item_post.user.avatar.url , class:"w-8 h-8 rounded-full border border-gray-200" %>
-      <p class="text-md text-gray-800"><%= item_post.user.name %></p>  <%# ここで余計なクエリが発行されないよう、indexアクションでincludesを使ってN+1問題を回避している %>
-    </div>
-    <div class= "absolute top-4 right-4">
-      <p class="text-md text-gray-800"><%= item_post.created_at.strftime("%y/%m/%d %H:%M:%S") %></h1>
-    </div>
+<div class="relative bg-gray-50 p-4 border rounded-lg shadow transition-transform duration-300 hover:scale-105"
+     data-url="<%= item_post_path(item_post) %>" 
+     onclick="location.href='<%= item_post_path(item_post) %>';">
+  
+  <div class= "absolute top-4 left-4 flex flex-row gap-4">
+    <%= image_tag item_post.user.avatar.url , class:"w-8 h-8 rounded-full border border-gray-200" %>
+    <p class="text-md text-gray-800"><%= item_post.user.name %></p>  <%# ここで余計なクエリが発行されないよう、indexアクションでincludesを使ってN+1問題を回避している %>
+  </div>
+  <div class= "absolute top-4 right-4">
+    <p class="text-md text-gray-800"><%= item_post.created_at.strftime("%y/%m/%d %H:%M:%S") %></p>
+  </div>
 
-    <!-- 選択した画像がある場合には画像を表示、なければグレーの画像を表示 -->
-    <div class="flex justify-center mt-12">
-      <% if item_post.item_post_image_url.present? %>
-        <%= image_tag item_post.item_post_image_url, class: "w-72 h-48 object-cover", alt: "Item post image" %><!-- object-coverで余白を埋める-->
-      <% else %>
-        <div class="w-72 h-48 bg-gray-200"></div>
-      <% end %>
-    </div>
-  <% end %>
-  <%= link_to item_post.title, item_post_path(item_post), class: 'text-2xl font-bold text-gray-800 hover:bg-gray-300' %>
+  <!-- 選択した画像がある場合には画像を表示、なければデフォルトの画像を表示 -->
+  <div class="flex justify-center mt-12">
+    <% if item_post.item_post_image_url.present? %>
+      <%= image_tag item_post.item_post_image_url, class: "rounded-lg w-72 h-48 object-cover", alt: "Item post image" %><!-- object-coverで余白を埋める-->
+    <% else %>
+      <div class="w-72 h-48 bg-gray-200"></div>
+    <% end %>
+  </div>
+ 
+  <h2 class = 'text-2xl font-bold'><%= item_post.title %></h2>
 
   <p class="text-sm text-gray-500 m-8"><%= item_post.body.truncate(100) %></p>
   <div class="absolute bottom-5 left-4 flex items-center gap-6">

--- a/app/views/item_posts/show.html.erb
+++ b/app/views/item_posts/show.html.erb
@@ -15,7 +15,7 @@
 
     <div class ="flex flex-col gap-6">
       <% if @item_post.item_post_image_url.present? %>
-        <%= image_tag @item_post.item_post_image.url %>
+        <%= image_tag @item_post.item_post_image.url, class: "rounded-lg" %>
       <% end %>
     </div>
   


### PR DESCRIPTION
概要
各投稿のクリックすると詳細画面に遷移できるよう実装

内容
・各投稿をホバーすると大きくなるように実装
・そのまま押すと詳細画面に遷移できるよう実装（どこを押しても可）
・投稿された画像に丸みをつける（詳細画面も含む）