### PR TITLE
ログイン状態の保持機能を実装

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -30,15 +30,27 @@
       <%= f.email_field :email, autofocus: true, class: "border border-gray-300 rounded-lg px-4 py-2 focus:ring focus:ring-blue-300 focus:outline-none" %>   
     </div>
   
-    <div class="flex flex-col mb-6">     
+    <div class="flex flex-col mb-4">     
       <%= f.label :password, "パスワード", class: "my-10 text-lg font-medium text-gray-700 mb-2" %>  
-      <%= f.password_field :password, class: "border border-gray-300 rounded-lg px-4 py-2 focus:ring focus:ring-blue-300 focus:outline-none" %>   
-      <%= link_to "パスワードをお忘れの方はこちら", new_user_password_path, class: "flex justify-end p-2 hover:underline text-sky-500" %>
+      <%= f.password_field :password, class: "border border-gray-300 rounded-lg px-4 py-2 focus:ring focus:ring-blue-300 focus:outline-none" %>
     </div>
 
+    <div class="flex flex-col justify-start md:flex-row md:justify-between md:items-center mx-2">
+      <!--左側-->
+      <div class ="flex items-center gap-2">
+        <% if devise_mapping.rememberable? %>
+          <%= f.check_box :remember_me %>
+          <%= f.label :remember_me, "ログイン状態を保持", class: "text-nowrap" %>
+        <% end %>
+      </div>
+      <!--右側-->
+      <div>
+        <%= link_to "パスワードをお忘れの方はこちら", new_user_password_path, class: "hover:underline text-sky-500" %>
+      </div>
+    </div>
 
     <div class="text-center my-20"> 
-      <%= f.submit "ログイン", class: "bg-sky-100 rounded-2xl px-6 py-2 hover:bg-sky-300 shadow-xl" %> 
+      <%= f.submit "ログイン", class: "bg-sky-100 rounded-xl px-6 py-2 hover:bg-sky-300 shadow-xl" %> 
     </div>
   <% end %>
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -164,13 +164,15 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  
+  # ログイン状態を保持する期間を2週間に設定
+  config.remember_for = 2.weeks
 
-  # Invalidates all the remember me tokens when the user signs out.
+  # ログアウト時に全てのデバイスでセッションを無効化
   config.expire_all_remember_me_on_sign_out = true
 
-  # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  # ログインするたびに期間がリセットされ、ログイン保持期間を更新（ログインするたび2週間に更新）
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.


### PR DESCRIPTION
**概要**
ログイン状態の保持機能を実装

**内容**

- ログイン状態を保持するためconfig/initializers/devise.rbを以下の修正


> ログイン状態を保持する期間を2週間に設定

> ログアウト時に全てのデバイスでセッションを無効化

>  ログインするたびに期間がリセットされ、ログイン保持期間を更新（ログインするたび2週間に更新）

- ログイン画面にチェックボックスを実装

【参考】
開発環境で以下の通りデベロッパーツールで確認したところ、cookieが発行されていた
![image](https://github.com/user-attachments/assets/3f949f59-ad6f-4e77-af62-c03bb39ba85e)
