### PR TITLE
gem「bullet」を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,11 @@ gem 'omniauth-rails_csrf_protection'
 
 gem 'mini_magick'
 
+#N+1問題を検知可能
+group :development do
+  gem 'bullet'
+end
+
 #dotenv-rails を 開発環境 と テスト環境 でのみ有効にする（本番環境では不要なので有効にしない（セキュリティ対策）。）
 gem 'dotenv-rails', groups: [:development, :test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,9 @@ GEM
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     builder (3.3.0)
+    bullet (8.0.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -373,6 +376,7 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uniform_notifier (1.17.0)
     uri (1.0.3)
     version_gem (1.1.7)
     warden (1.2.9)
@@ -400,6 +404,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   carrierwave (~> 3.0)
   cssbundling-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time


### PR DESCRIPTION
**概要**
gem「bullet」を導入

**内容**
・Gemfileに
```
group :development do
  gem 'bullet'
end
```
を記述し、docker compose exec web bundle install　を実施

・「docker compose exec web bundle exec rails g bullet:install」を実施し、config/environments/development.rbにデフォルトで、以下のコードを生成
```
config.after_initialize do
    Bullet.enable        = true
    Bullet.alert         = true
    Bullet.bullet_logger = true
    Bullet.console       = true
    Bullet.rails_logger  = true
    Bullet.add_footer    = true
  end
```