### PR TITLE
bulletにより表示される検知を直してN+1問題を解決

### DIFF
--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -45,7 +45,7 @@ class HabitPostsController < ApplicationController
 
   def habit_likes
     @q = current_user.liked_habit_posts.ransack(params[:q])
-    @habit_like_posts = @q.result(distinct: true).includes(:user, :habit_comments, :habit_tag).order(created_at: :desc).page(params[:page]).per(20)
+    @habit_like_posts = @q.result(distinct: true).includes(:user, :habit_tag).order(created_at: :desc).page(params[:page]).per(20)
     @active_tab = "habit_likes"
     render "profiles/show"
   end

--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -60,7 +60,7 @@ class HabitPostsController < ApplicationController
   end
 
   def my_habit_posts
-    @my_habit_posts = current_user.habit_posts.includes(:user, :habit_comments, :habit_likes, :habit_tag).order(created_at: :desc)
+    @my_habit_posts = current_user.habit_posts.includes(:user, :habit_tag).order(created_at: :desc)
     @active_tab = "my_habit_posts"
     render "profiles/show"
   end

--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -51,7 +51,7 @@ class HabitPostsController < ApplicationController
   end
   
   def ranking
-    @habit_post_ranking = HabitPost.find(HabitLike.group(:habit_post_id).order('count(id) desc').limit(5).pluck(:habit_post_id))
+    @habit_post_ranking = HabitPost.includes(:user).find(HabitLike.group(:habit_post_id).order('count(id) desc').limit(5).pluck(:habit_post_id))
   end
 
   def search

--- a/app/controllers/habit_posts_controller.rb
+++ b/app/controllers/habit_posts_controller.rb
@@ -4,7 +4,7 @@ class HabitPostsController < ApplicationController
 
   def index
     @q = HabitPost.ransack(params[:q])
-    @habit_posts = @q.result(distinct: true).includes(:user, :habit_comments, :habit_likes, :habit_tag).order(created_at: :desc).page(params[:page]).per(12)
+    @habit_posts = @q.result(distinct: true).includes(:user, :habit_tag).order(created_at: :desc).page(params[:page]).per(12)
   end
 
   def new

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -51,7 +51,7 @@ class ItemPostsController < ApplicationController
   end
 
   def ranking
-    @item_post_ranking = ItemPost.find(ItemLike.group(:item_post_id).order('count(id) desc').limit(5).pluck(:item_post_id))
+    @item_post_ranking = ItemPost.includes(:user).find(ItemLike.group(:item_post_id).order('count(id) desc').limit(5).pluck(:item_post_id))
   end
 
   def search

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -45,7 +45,7 @@ class ItemPostsController < ApplicationController
   
   def item_likes
     @q = current_user.liked_item_posts.ransack(params[:q])
-    @item_like_posts = @q.result(distinct: true).includes(:user, :item_comments, :item_tag).order(created_at: :desc).page(params[:page]).per(20)
+    @item_like_posts = @q.result(distinct: true).includes(:user, :item_tag).order(created_at: :desc).page(params[:page]).per(20)
     @active_tab = "item_likes"
     render "profiles/show"
   end

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -60,7 +60,7 @@ class ItemPostsController < ApplicationController
   end
 
   def my_item_posts
-    @my_item_posts = current_user.item_posts.includes(:user, :item_comments, :item_likes, :item_tag).order(created_at: :desc)
+    @my_item_posts = current_user.item_posts.includes(:user, :item_tag).order(created_at: :desc)
     @active_tab = "my_item_posts"
     render "profiles/show"
   end

--- a/app/controllers/item_posts_controller.rb
+++ b/app/controllers/item_posts_controller.rb
@@ -4,7 +4,7 @@ class ItemPostsController < ApplicationController
   
   def index
     @q = ItemPost.ransack(params[:q])
-    @item_posts = @q.result(distinct: true).includes(:user, :item_comments, :item_likes, :item_tag).order(created_at: :desc).page(params[:page]).per(12)
+    @item_posts = @q.result(distinct: true).includes(:user, :item_tag).order(created_at: :desc).page(params[:page]).per(12)
   end
 
   def new

--- a/app/models/habit_comment.rb
+++ b/app/models/habit_comment.rb
@@ -1,6 +1,6 @@
 class HabitComment < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535}
 
-  belongs_to :habit_post
+  belongs_to :habit_post, counter_cache: true # いいねが押されたら、habit_postのhabit_comments_countに+1(-1)カウントするよう設定
   belongs_to :user
 end

--- a/app/models/habit_like.rb
+++ b/app/models/habit_like.rb
@@ -1,6 +1,6 @@
 class HabitLike < ApplicationRecord
   belongs_to :user
-  belongs_to :habit_post, counter_cashe: true # いいねが押されたら、habit_postのhabit_likes_countに+1(-1)カウントするよう設定
+  belongs_to :habit_post, counter_cache: true # いいねが押されたら、habit_postのhabit_likes_countに+1(-1)カウントするよう設定
 
   # どのカラムを検索対象にして許可するかを設定
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/habit_like.rb
+++ b/app/models/habit_like.rb
@@ -1,6 +1,6 @@
 class HabitLike < ApplicationRecord
   belongs_to :user
-  belongs_to :habit_post
+  belongs_to :habit_post, counter_cashe: true # いいねが押されたら、habit_postのhabit_likes_countに+1(-1)カウントするよう設定
 
   # どのカラムを検索対象にして許可するかを設定
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/item_comment.rb
+++ b/app/models/item_comment.rb
@@ -1,6 +1,6 @@
 class ItemComment < ApplicationRecord
   validates :body, presence: true, length: { maximum: 65_535 }
   
-  belongs_to :item_post
+  belongs_to :item_post, counter_cache: true # いいねが押されたら、item_commentのitem_comments_countに+1(-1)カウントするよう設定
   belongs_to :user
 end

--- a/app/models/item_like.rb
+++ b/app/models/item_like.rb
@@ -1,6 +1,6 @@
 class ItemLike < ApplicationRecord
   belongs_to :user
-  belongs_to :item_post, counter_cashe: true # いいねが押されたら、item_postのitem_likes_countに+1(-1)カウントするよう設定
+  belongs_to :item_post, counter_cache: true # いいねが押されたら、item_postのitem_likes_countに+1(-1)カウントするよう設定
 
   # どのカラムを検索対象にして許可するかを設定
   def self.ransackable_attributes(auth_object = nil)

--- a/app/models/item_like.rb
+++ b/app/models/item_like.rb
@@ -1,6 +1,6 @@
 class ItemLike < ApplicationRecord
   belongs_to :user
-  belongs_to :item_post
+  belongs_to :item_post, counter_cashe: true # いいねが押されたら、item_postのitem_likes_countに+1(-1)カウントするよう設定
 
   # どのカラムを検索対象にして許可するかを設定
   def self.ransackable_attributes(auth_object = nil)

--- a/app/views/habit_posts/_habit_like.html.erb
+++ b/app/views/habit_posts/_habit_like.html.erb
@@ -1,3 +1,3 @@
 <%= link_to habit_post_habit_likes_path(habit_post.id), id: "like-button-for-habit-post-#{habit_post.id}", class: "text-lg", data: { turbo_method: :post } do %>
-  <i class="fa-solid fa-moon"></i><%= habit_post.habit_likes.count %>
+  <i class="fa-solid fa-moon"></i><%= habit_post.habit_likes_count %>
 <% end %>

--- a/app/views/habit_posts/_habit_post.html.erb
+++ b/app/views/habit_posts/_habit_post.html.erb
@@ -53,6 +53,6 @@
   <!-- コメント -->
   <div class="absolute bottom-4 right-3 text-lg">
     <i class="fa-regular fa-comment"></i>
-    <%= habit_post.habit_comments.count %>
+    <%= habit_post.habit_comments_count %>
   </div>
 </div>

--- a/app/views/habit_posts/_habit_unlike.html.erb
+++ b/app/views/habit_posts/_habit_unlike.html.erb
@@ -1,5 +1,5 @@
 <% habit_like = current_user.habit_likes.find_by(habit_post_id: habit_post.id) %>
 
 <%= link_to habit_post_habit_like_path(habit_post.id, habit_like), method: :delete, id: "unlike-button-for-habit-post-#{habit_post.id}", class: "text-xl text-yellow-400", data: { turbo_method: :delete } do %>
-  <i class="fa-solid fa-moon"></i><%= habit_post.habit_likes.count %>
+  <i class="fa-solid fa-moon"></i><%= habit_post.habit_likes_count %>
 <% end %>

--- a/app/views/habit_posts/ranking.html.erb
+++ b/app/views/habit_posts/ranking.html.erb
@@ -18,7 +18,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= image_tag "gold.png", alt: '金の冠のアイコン', class: "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8" %><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.habit_likes.count %></td>
+          <td class = "py-4"><%= rank.habit_likes_count %></td>
         </tr>
       <% elsif i == 2 %>
         <tr class = "text-xs md:text-base lg:text-xl bg-white shadow transition-transform duration-300 hover:scale-105"
@@ -26,7 +26,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= image_tag "silver.png", alt: '銀の冠のアイコン', class: "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8" %><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.habit_likes.count %></td>
+          <td class = "py-4"><%= rank.habit_likes_count %></td>
         </tr>
       <% elsif i == 3 %>
         <tr class = "text-xs md:text-base lg:text-xl bg-gray-100 shadow transition-transform duration-300 hover:scale-105"
@@ -34,7 +34,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= image_tag "bronze.png", alt: '銅の冠のアイコン', class: "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8" %><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.habit_likes.count %></td>
+          <td class = "py-4"><%= rank.habit_likes_count %></td>
         </tr>
       <% else %>
         <tr class = "text-xs md:text-base lg:text-xl odd:bg-white even:bg-gray-100 shadow transition-transform duration-300 hover:scale-105"
@@ -42,7 +42,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.habit_likes.count %></td>
+          <td class = "py-4"><%= rank.habit_likes_count %></td>
         </tr>
       <% end %>
     <% end %>

--- a/app/views/item_posts/_item_like.html.erb
+++ b/app/views/item_posts/_item_like.html.erb
@@ -1,3 +1,3 @@
 <%= link_to item_post_item_likes_path(item_post.id), id: "like-button-for-item-post-#{item_post.id}", class: "text-lg", data: { turbo_method: :post } do %>
-  <i class="fa-solid fa-moon"></i><%= item_post.item_likes.count %>
+  <i class="fa-solid fa-moon"></i><%= item_post.item_likes_count %>
 <% end %>

--- a/app/views/item_posts/_item_post.html.erb
+++ b/app/views/item_posts/_item_post.html.erb
@@ -53,6 +53,6 @@
   <!-- コメント -->
   <div class="absolute bottom-4 right-3 text-lg">
     <i class="fa-regular fa-comment"></i>
-    <%= item_post.item_comments.count %>
+    <%= item_post.item_comments_count %>
   </div>
 </div>

--- a/app/views/item_posts/_item_unlike.html.erb
+++ b/app/views/item_posts/_item_unlike.html.erb
@@ -1,5 +1,5 @@
 <% item_like = current_user.item_likes.find_by(item_post_id: item_post.id) %>
 
 <%= link_to item_post_item_like_path(item_post.id,item_like), id: "unlike-button-for-item-post-#{item_post.id}", class: "text-xl text-yellow-400", data: { turbo_method: :delete } do %>
-  <i class="fa-solid fa-moon"></i><%= item_post.item_likes.count %>
+  <i class="fa-solid fa-moon"></i><%= item_post.item_likes_count %>
 <% end %>

--- a/app/views/item_posts/ranking.html.erb
+++ b/app/views/item_posts/ranking.html.erb
@@ -19,7 +19,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= image_tag "gold.png", alt: '金の冠のアイコン', class: "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8" %><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.item_likes.count %></td>
+          <td class = "py-4"><%= rank.item_likes_count %></td>
         </tr>
       <% elsif i == 2 %>
         <!-- ionclick="locationで 行をクリックした際に実行されるジャバスクリプトを埋め込み、その遷移先を指定-->
@@ -28,7 +28,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= image_tag "silver.png", alt: '銀の冠のアイコン', class: "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8" %><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.item_likes.count %></td>
+          <td class = "py-4"><%= rank.item_likes_count %></td>
         </tr>
       <% elsif i == 3 %>
         <!-- ionclick="locationで 行をクリックした際に実行されるジャバスクリプトを埋め込み、その遷移先を指定-->
@@ -37,7 +37,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= image_tag "bronze.png", alt: '銅の冠のアイコン', class: "w-4 h-4 md:w-6 md:h-6 lg:w-8 lg:h-8" %><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.item_likes.count %></td>
+          <td class = "py-4"><%= rank.item_likes_count %></td>
         </tr>
       <% else %>
         <!-- ionclick="locationで 行をクリックした際に実行されるジャバスクリプトを埋め込み、その遷移先を指定-->
@@ -46,7 +46,7 @@
           <td class = "flex flex-row items-center justify-center gap-2 py-4"><%= "#{i}" %></td>
           <td class = "py-4 font-bold text-gray-800"><%= rank.title %></td>
           <td class = "py-4"><%= rank.user.name %></td>
-          <td class = "py-4"><%= rank.item_likes.count %></td>
+          <td class = "py-4"><%= rank.item_likes_count %></td>
         </tr>
       <% end %>
     <% end %>

--- a/db/migrate/20250525010640_add_item_likes_count_to_item_posts.rb
+++ b/db/migrate/20250525010640_add_item_likes_count_to_item_posts.rb
@@ -1,0 +1,5 @@
+class AddItemLikesCountToItemPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :item_posts, :item_likes_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20250525011512_add_habit_likes_count_to_habit_posts.rb
+++ b/db/migrate/20250525011512_add_habit_likes_count_to_habit_posts.rb
@@ -1,0 +1,5 @@
+class AddHabitLikesCountToHabitPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :habit_posts, :habit_likes_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20250525043807_add_item_comments_count_to_item_posts.rb
+++ b/db/migrate/20250525043807_add_item_comments_count_to_item_posts.rb
@@ -1,0 +1,5 @@
+class AddItemCommentsCountToItemPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :item_posts, :item_comments_count, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20250525050004_add_habit_comments_count_to_habit_posts.rb
+++ b/db/migrate/20250525050004_add_habit_comments_count_to_habit_posts.rb
@@ -1,0 +1,5 @@
+class AddHabitCommentsCountToHabitPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :habit_posts, :habit_comments_count, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_09_202348) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_25_010640) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_09_202348) do
     t.datetime "updated_at", null: false
     t.string "item_post_image"
     t.bigint "item_tag_id", null: false
+    t.integer "item_likes_count", default: 0, null: false
     t.index ["item_tag_id"], name: "index_item_posts_on_item_tag_id"
     t.index ["user_id"], name: "index_item_posts_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_25_011512) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_25_043807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -90,6 +90,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_25_011512) do
     t.string "item_post_image"
     t.bigint "item_tag_id", null: false
     t.integer "item_likes_count", default: 0, null: false
+    t.integer "item_comments_count", default: 0, null: false
     t.index ["item_tag_id"], name: "index_item_posts_on_item_tag_id"
     t.index ["user_id"], name: "index_item_posts_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_25_043807) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_25_050004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_25_043807) do
     t.string "habit_post_image", null: false
     t.bigint "habit_tag_id", null: false
     t.integer "habit_likes_count", default: 0, null: false
+    t.integer "habit_comments_count", default: 0, null: false
     t.index ["habit_tag_id"], name: "index_habit_posts_on_habit_tag_id"
     t.index ["user_id"], name: "index_habit_posts_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_05_25_010640) do
+ActiveRecord::Schema[7.1].define(version: 2025_05_25_011512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,6 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_05_25_010640) do
     t.datetime "updated_at", null: false
     t.string "habit_post_image", null: false
     t.bigint "habit_tag_id", null: false
+    t.integer "habit_likes_count", default: 0, null: false
     t.index ["habit_tag_id"], name: "index_habit_posts_on_habit_tag_id"
     t.index ["user_id"], name: "index_habit_posts_on_user_id"
   end


### PR DESCRIPTION
**概要**
bulletにより表示される検知を直してN+1問題を解決

**内容**
・item(habit)_postsテーブルにcounter_cacheを導入するため、item(habit)_likes_countカラムとitem(habit)_comments_countカラムを追加（参考　https://qiita.com/Tohru-f/items/becb99329cb35c068877）
・上記で追加したカラムに、個数を格納するため、Item(habit)LikeモデルとItem(habit)Commentsモデルにcounter_cache: trueを記述
・各ビューのitem(habit)_likes.countとitem(habit)_comments.countを、item(habit)_likes_countとitem(habit)_comments_countに修正
・その他、bulletにより検知されていた、includesに含めていた不要なモデルを削除