### PR TITLE
マイページのいいね一覧の検索窓を削除

### DIFF
--- a/app/views/habit_posts/_habit_likes.html.erb
+++ b/app/views/habit_posts/_habit_likes.html.erb
@@ -1,11 +1,8 @@
 <!-- 習慣投稿の中でいいねした投稿をマイページで表示させるためのパーシャル -->
 
-<h2 class="text-2xl font-bold my-6 ">【習慣】<br>いいねした投稿一覧</h2>
-<div class = "flex justify-center my-12">
-  <%= render 'habit_posts/search_form', q: @q, url: habit_likes_habit_posts_path %>
-</div>
+<h2 class="text-2xl font-bold my-6">【習慣】<br>いいねした投稿一覧</h2>
 <% if @habit_like_posts.present? %>
-  <div class="grid grid-cols-1 gap-6">
+  <div class="grid grid-cols-1 gap-6 my-12">
     <%= render habit_like_posts %>
   </div>
   <%= paginate habit_like_posts %>

--- a/app/views/item_posts/_item_likes.html.erb
+++ b/app/views/item_posts/_item_likes.html.erb
@@ -1,11 +1,8 @@
 <!-- アイテム投稿の中でいいねした投稿をマイページで表示させるためのパーシャル -->
 
 <h2 class="text-2xl font-bold my-6 ">【アイテム】<br>いいねした投稿一覧</h2>
-<div class = "flex justify-center my-12">
-  <%= render 'item_posts/search_form', q: @q, url: item_likes_item_posts_path %>
-</div>
 <% if @item_like_posts.present? %>
-  <div class="grid grid-cols-1 gap-6">
+  <div class="grid grid-cols-1 gap-6 my-12">
     <%= render item_like_posts %>
   </div>
   <%= paginate item_like_posts %>


### PR DESCRIPTION
**概要**
マイページのいいね一覧の検索窓を削除

**内容**
最初のうちは投稿自体が少なくいいねする投稿も少ないと思ったため削除（必要になったら再度実装する可能性あり）