### PR TITLE
バリデーションエラー時の文字数カウンターを発火させるよう修正

### DIFF
--- a/app/javascript/character_counter.js
+++ b/app/javascript/character_counter.js
@@ -1,4 +1,5 @@
-document.addEventListener('turbo:load', function() {
+//関数で処理をまとめる
+function CharacterCounter() {
   
   //アイテム投稿（編集）のtitleの文字数カウンター
 
@@ -78,4 +79,8 @@ document.addEventListener('turbo:load', function() {
       bodyCountwrap.style.color = 'red'
     }
   });
-});
+}
+
+// イベントリスナー（loadもrender(バリデーションエラー時）もカバー）
+document.addEventListener('turbo:load', CharacterCounter);
+document.addEventListener('turbo:render', CharacterCounter);


### PR DESCRIPTION
**概要**
バリデーションエラー時の文字数カウンターを発火させるよう修正

**内容**
・イベントリスナーの関数をひとまとまりにして再利用可能の状態に修正
・関数記述後、以下を記述し、renderでバリデーションエラーが起きた時にも文字数カウンターを正常に発火できるよう修正
```
document.addEventListener('turbo:load', CharacterCounter);
document.addEventListener('turbo:render', CharacterCounter);
```
