### PR TITLE
バリデーションの修正

### DIFF
--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,5 +1,6 @@
 class Diary < ApplicationRecord
   validates :date, presence: true
   validates :title, presence: true, length: { maximum: 50 }
+  validates :content, length: { maximum: 1000 }
   belongs_to :user
 end

--- a/app/models/diary.rb
+++ b/app/models/diary.rb
@@ -1,5 +1,5 @@
 class Diary < ApplicationRecord
   validates :date, presence: true
-  validates :title, presence: true, length: { maximum: 20 }
+  validates :title, presence: true, length: { maximum: 50 }
   belongs_to :user
 end

--- a/app/models/habit_post.rb
+++ b/app/models/habit_post.rb
@@ -1,5 +1,5 @@
 class HabitPost < ApplicationRecord
-  validates :title, presence: true, length: { maximum: 100 }
+  validates :title, presence: true, length: { maximum: 50 }
   validates :body, presence: true, length: { maximum: 1000 }
   validates :habit_post_image, presence: true, if: -> { Rails.env.production? } # 本番環境のみ画像は必須に設定（開発環境ではダミーデータは画像を必須にする必要ないため）
 

--- a/app/models/item_post.rb
+++ b/app/models/item_post.rb
@@ -1,6 +1,6 @@
 class ItemPost < ApplicationRecord
   #バリデーション設定(DBに保存される前にデータが正しい形式や条件を満たしているかを「presence」や「length」で確認)
-  validates :title, presence: true, length: { maximum: 100 } #空でない、最大100文字
+  validates :title, presence: true, length: { maximum: 50 } #空でない、最大50文字
   validates :body, presence: true, length: { maximum: 1000 } #空でない、最大1000文字
 
   belongs_to :user

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,6 +16,7 @@ ja:
       diary:
         date: '日付'
         title: 'タイトル'
+        content: '日記内容'
     errors:
       models:
         habit_post:


### PR DESCRIPTION
**概要**
バリデーションの修正

**内容**
・アイテム投稿のタイトルのバリデーション（文字数）を変更（100→50）
・習慣投稿のタイトルのバリデーション（文字数）を変更（100→50）
・日記投稿のタイトルのバリデーション（文字数）を変更（100→50）
・日記投稿の内容のバリデーションを追加（1000まで）
・日記投稿の内容がバリデーションに引っかかった場合のエラーメッセージのため、i18nを追加