### PR TITLE
投稿詳細を押した時のローディングアニメーションを実装

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import LoadingController from "./loading_controller"
+application.register("loading", LoadingController)

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="loading"
+export default class extends Controller {
+  connect() {
+  }
+}

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -2,6 +2,17 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="loading"
 export default class extends Controller {
+  static targets = ["spinner"]
+  
   connect() {
+    this.hide()
+  }
+  
+  show() {
+    this.spinnerTarget.classList.remove("hidden")
+  }
+  
+  hide() {
+    this.spinnerTarget.classList.add("hidden")
   }
 }

--- a/app/javascript/controllers/loading_controller.js
+++ b/app/javascript/controllers/loading_controller.js
@@ -6,7 +6,11 @@ export default class extends Controller {
   
   connect() {
     this.hide()
-  }
+    // ブラウザバックでローディングアニメーションが表示されないよう設定
+    window.addEventListener("pageshow", () => {
+        this.hide();
+      });
+    }
   
   show() {
     this.spinnerTarget.classList.remove("hidden")

--- a/app/views/habit_posts/_habit_post.html.erb
+++ b/app/views/habit_posts/_habit_post.html.erb
@@ -1,7 +1,8 @@
 <div class="relative bg-gray-50 p-4 border rounded-lg shadow transition-transform duration-300 hover:scale-105">
 
   <!-- 指定の範囲をクリックした際に詳細画面へ遷移 -->
-  <div data-url="<%= habit_post_path(habit_post) %>" 
+  <div data-url="<%= habit_post_path(habit_post) %>"
+       data-action="click->loading#show"
        onclick="location.href='<%= habit_post_path(habit_post) %>';">
     <div class= "absolute top-4 left-4 flex flex-row gap-4">
       <%= image_tag habit_post.user.avatar.url , class:"w-8 h-8 rounded-full border border-gray-200" %>

--- a/app/views/item_posts/_item_post.html.erb
+++ b/app/views/item_posts/_item_post.html.erb
@@ -1,7 +1,8 @@
 <div class="relative bg-gray-50 p-4 border rounded-lg shadow transition-transform duration-300 hover:scale-105">
      
   <!-- 指定の範囲をクリックした際に詳細画面へ遷移 -->
-  <div data-url="<%= item_post_path(item_post) %>" 
+  <div data-url="<%= item_post_path(item_post) %>"
+       data-action="click->loading#show"
        onclick="location.href='<%= item_post_path(item_post) %>';">
     <div class= "absolute top-4 left-4 flex flex-row gap-4">
       <%= image_tag item_post.user.avatar.url , class:"w-8 h-8 rounded-full border border-gray-200" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
     <div data-controller="loading">
       <div data-loading-target="spinner" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
         <div class="h-[150px] w-[150px] flex items-center justify-center">
-          <span class="loading loading-spinner text-default w-full h-full"></span>
+          <%= image_tag("loading.gif", class: "w-full h-full") %>
         </div>
       </div>
       <%= render 'shared/header' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,13 +25,21 @@
   </head>
 
   <body class= "flex flex-col min-h-screen">
-    <%= render 'shared/header' %>
-    <%= render 'shared/flash_message' %>
+    <!-- 全てのページでローディングアニメーションが表示されるように記述 -->
+    <div data-controller="loading">
+      <div data-loading-target="spinner" class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40 hidden">
+        <div class="h-[150px] w-[150px] flex items-center justify-center">
+          <span class="loading loading-spinner text-default w-full h-full"></span>
+        </div>
+      </div>
+      <%= render 'shared/header' %>
+      <%= render 'shared/flash_message' %>
 
-    <!-- flex-grow:main のコンテンツが少ない場合でも、フッターが自然にページの一番下に配置される  -->
-    <div class="flex-grow">
-      <%= yield %>
+      <!-- flex-grow:main のコンテンツが少ない場合でも、フッターが自然にページの一番下に配置される  -->
+      <div class="flex-grow">
+        <%= yield %>
+      </div>
+      <%= render 'shared/footer' %>
     </div>
-    <%= render 'shared/footer' %>
   </body>
 </html>


### PR DESCRIPTION
**概要**
投稿詳細を押した時のローディングアニメーションを実装
（若干、遅いと感じたため）

**内容**
・app/views/layouts/application.html.erb　に全ページで反映されるよう実装（今後のため）
・アニメーション動画を挿入
・app/javascript/controllers/loading_controller.jsを生成・記述（ブラウザバックでアニメーションが表示されないよう記述）
・アイテム（習慣）投稿の詳細画面遷移時に、アニメーションが表示されるよう「data-action="click->loading#show"」を記述
