### PR TITLE
ItemPostモデルのバリデーションに関するRSpec（テストコード）を実装

### DIFF
--- a/spec/factories/item_posts.rb
+++ b/spec/factories/item_posts.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :item_post do
-    
+    title { "テストタイトル"}
+    body { "テスト本文"}
+    association :user
+    association :item_tag
   end
 end

--- a/spec/factories/item_posts.rb
+++ b/spec/factories/item_posts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item_post do
+    
+  end
+end

--- a/spec/factories/item_tags.rb
+++ b/spec/factories/item_tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :item_tag do
+    name { "テストタグ"}
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { "テストネーム"}
+    sequence(:email) { |n| "runteq_#{n}@example.com" }
+    password { "password" }
+    password_confirmation { "password" }
+  end
+end

--- a/spec/models/item_post_spec.rb
+++ b/spec/models/item_post_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe ItemPost, type: :model do #ItemPostのモデルであることを意味
+  describe 'バリデーションチェック' do
+    it 'titleとbodyが有効であること' do
+      item_post = build(:item_post)
+      expect(item_post).to be_valid # be_validでitem_postがバリデーションが通るかを検証
+    end
+  end
+end

--- a/spec/models/item_post_spec.rb
+++ b/spec/models/item_post_spec.rb
@@ -3,8 +3,32 @@ require 'rails_helper'
 RSpec.describe ItemPost, type: :model do #ItemPostのモデルであることを意味
   describe 'バリデーションチェック' do
     it 'titleとbodyが有効であること' do
-      item_post = build(:item_post)
+      item_post = build(:item_post) # factory botによりitem_post.rbよりデータを生成
       expect(item_post).to be_valid # be_validでitem_postがバリデーションが通るかを検証
+    end
+
+    it 'titleが空だと無効であること' do
+      item_post = build(:item_post, title: nil) # factory botにより生成されたtitleをnilに上書き
+      item_post.valid? # バリデーションを通るか確認
+      expect(item_post.errors[:title]).not_to be_empty # エラーメッセージが空でないかを判定
+    end
+
+    it 'titleが51文字以上だと無効であること' do
+      item_post = build(:item_post, title: "テストタイトル" * 8)
+      item_post.valid?
+      expect(item_post.errors[:title]).not_to be_empty
+    end
+
+    it 'bodyが空だと無効であること' do
+      item_post = build(:item_post, body: nil)
+      item_post.valid?
+      expect(item_post.errors[:body]).not_to be_empty
+    end
+
+    it 'bodyが1001文字以上だと無効であること' do
+      item_post = build(:item_post, body: "テスト本文" * 201)
+      item_post.valid?
+      expect(item_post.errors[:body]).not_to be_empty
     end
   end
 end

--- a/spec/models/item_tag_spec.rb
+++ b/spec/models/item_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,9 @@ RSpec.configure do |config|
     Rails.root.join('spec/fixtures')
   ]
 
+  # FactoryBotを省略して書くことができる
+  config.include FactoryBot::Syntax::Methods
+
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
**概要**
ItemPostモデルのバリデーションに関するRSpec（テストコード）を実装

**内容**
・spec/factories/item_posts.rbを生成
・spec/factories/item_tags.rbを生成
・spec/factories/users.rbを生成
・spec/models/item_post_spec.rbを生成し、テストコードを記述
・spec/models/item_tag_spec.rbを生成
・spec/models/user_spec.rbを生成
・spec/rails_helper.rbにconfig.include FactoryBot::Syntax::Methodsを記述