### PR TITLE
習慣投稿のモデルに関するRSpec（テストコード）を実装

### DIFF
--- a/spec/factories/habit_comments.rb
+++ b/spec/factories/habit_comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :habit_comment do
+    body { "テスト本文"}
+    association :user
+    association :habit_post
+  end
+end

--- a/spec/factories/habit_posts.rb
+++ b/spec/factories/habit_posts.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :habit_post do
+    
+  end
+end

--- a/spec/models/habit_comment_spec.rb
+++ b/spec/models/habit_comment_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe HabitComment, type: :model do
+  describe 'バリデーションチェック' do
+    it 'bodyが有効であること' do
+      habit_comment = build(:habit_comment) 
+      expect(habit_comment).to be_valid
+    end
+
+    it 'bodyが65,536以上だと無効であること' do
+      habit_comment = build(:habit_comment, body: "a" * 65_536)
+      habit_comment.valid?
+      expect(habit_comment.errors[:body]).not_to be_empty
+    end
+
+    it 'bodyが空だと無効であること' do
+      habit_comment = build(:habit_comment, body: nil )
+      habit_comment.valid?
+      expect(habit_comment.errors[:body]).not_to be_empty
+    end
+  end
+end

--- a/spec/models/habit_post_spec.rb
+++ b/spec/models/habit_post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe HabitPost, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
**概要**
習慣投稿のモデルに関するRSpec（テストコード）を実装

**内容**
・spec/factories/habit_comments.rbを生成し、ファクトリーボットを実装
・spec/factories/habit_posts.rbを生成
・spec/models/habit_comment_spec.rbを生成し、テストコードを実装
・spec/models/habit_post_spec.rbを生成