### PR TITLE
HabitPost、ItemTag、HabitTagモデルのバリデーションに関するRSpec（テストコード）を実装

### DIFF
--- a/spec/factories/habit_posts.rb
+++ b/spec/factories/habit_posts.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :habit_post do
-    
+    title { "テストタイトル"}
+    body { "テスト本文"}
+    association :user
+    association :habit_tag
   end
 end

--- a/spec/factories/habit_posts.rb
+++ b/spec/factories/habit_posts.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :habit_post do
     title { "テストタイトル"}
     body { "テスト本文"}
+    habit_post_image { "str.png" }
     association :user
     association :habit_tag
   end

--- a/spec/factories/habit_tags.rb
+++ b/spec/factories/habit_tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :habit_tag do
+    name { "テストタグ"}
+  end
+end

--- a/spec/models/habit_post_spec.rb
+++ b/spec/models/habit_post_spec.rb
@@ -1,5 +1,40 @@
 require 'rails_helper'
 
 RSpec.describe HabitPost, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    it 'titleとbodyとhabit_post_imageが有効であること' do
+      habit_post = build(:habit_post)
+      expect(habit_post).to be_valid 
+    end
+
+    it 'titleが空だと無効であること' do
+      habit_post = build(:habit_post, title: nil)
+      habit_post.valid?
+      expect(habit_post.errors[:title]).not_to be_empty
+    end
+
+    it 'titleが51文字以上だと無効であること' do
+      habit_post = build(:habit_post, title: "テストタイトル" * 8)
+      habit_post.valid?
+      expect(habit_post.errors[:title]).not_to be_empty
+    end
+
+    it 'bodyが空だと無効であること' do
+      habit_post = build(:habit_post, body: nil)
+      habit_post.valid?
+      expect(habit_post.errors[:body]).not_to be_empty
+    end
+
+    it 'bodyが1001文字以上だと無効であること' do
+      habit_post = build(:habit_post, body: "テスト本文" * 201)
+      habit_post.valid?
+      expect(habit_post.errors[:body]).not_to be_empty
+    end
+
+    it 'habit_post_imageが空だと無効であること' do
+      habit_post = build(:habit_post, habit_post_image: nil)
+      habit_post.valid?
+      expect(habit_post.errors[:habit_post_image]).not_to be_empty
+    end
+  end
 end

--- a/spec/models/habit_tag_spec.rb
+++ b/spec/models/habit_tag_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe HabitTag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    it 'nameが有効であること' do
+      habit_tag = build(:habit_tag)
+      expect(habit_tag).to be_valid
+    end
+
+    it 'nameが空だと無効であること' do
+      habit_tag = build(:habit_tag, name: nil)
+      habit_tag.valid?
+      expect(habit_tag.errors[:name]).not_to be_empty
+    end
+  end
 end

--- a/spec/models/habit_tag_spec.rb
+++ b/spec/models/habit_tag_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe HabitTag, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_tag_spec.rb
+++ b/spec/models/item_tag_spec.rb
@@ -1,5 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe ItemTag, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'バリデーションチェック' do
+    it 'nameが有効であること' do
+      item_tag = build(:item_tag)
+      expect(item_tag).to be_valid
+    end
+
+    it 'nameが空だと無効であること' do
+      item_tag = build(:item_tag, name: nil)
+      item_tag.valid?
+      expect(item_tag.errors[:name]).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
**概要**
HabitPost、ItemTag、HabitTagモデルのバリデーションに関するRSpec（テストコード）を実装

**内容**
・spec/factories/habit_posts.rbにファクトリーボットを記述
・spec/factories/habit_tags.rbにファクトリーボットを記述
・spec/models/habit_tag_spec.rbにテストコードを記述
・spec/models/item_tag_spec.rbにテストコードを記述
・spec/models/habit_post_spec.rbにテストコードを記述
