### PR TITLE
HabitPostモデルに関するテストコード(RSpec)を実装

### DIFF
--- a/spec/factories/habit_likes.rb
+++ b/spec/factories/habit_likes.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :habit_like do
+    association :user
+    association :habit_post
+  end
+end
+  

--- a/spec/models/habit_post_spec.rb
+++ b/spec/models/habit_post_spec.rb
@@ -37,4 +37,32 @@ RSpec.describe HabitPost, type: :model do
       expect(habit_post.errors[:habit_post_image]).not_to be_empty
     end
   end
+
+  describe 'アソシエーションチェック' do
+    it 'Userに属していること' do
+      user = create(:user)
+      habit_post = create(:habit_post, user_id: user.id)
+      expect(habit_post.user).to eq(user)
+    end
+
+    it 'HabitTagに属していること' do
+      habit_tag = create(:habit_tag)
+      habit_post = create(:habit_post, habit_tag_id: habit_tag.id)
+      expect(habit_post.habit_tag).to eq(habit_tag)
+    end
+
+    it 'HabitLikesを含んでいること' do
+      habit_post = create(:habit_post)
+      habit_like1 = create(:habit_like, habit_post_id: habit_post.id)
+      habit_like2 = create(:habit_like, habit_post_id: habit_post.id)
+      expect(habit_post.habit_likes).to include(habit_like1,habit_like2)
+    end
+
+    it 'HabitCommentを含んでいること' do
+      habit_post = create(:habit_post)
+      habit_comment1 = create(:habit_comment, habit_post_id: habit_post.id)
+      habit_comment2 = create(:habit_comment, habit_post_id: habit_post.id)
+      expect(habit_post.habit_comments).to include(habit_comment1,habit_comment2)
+    end
+  end
 end


### PR DESCRIPTION
**概要**
HabitPostモデルに関するテストコード(RSpec)を実装

**内容**
・HabitLikes.rb（ファクトリーボット）を生成
・「belongs_to :user」（アソシエーション）である「Userに属していること」を確認するためのテストコードを記述
・「belongs_to :habit_tag」（アソシエーション）である「HabitTagに属していること」を確認するためのテストコードを記述
・「has_many :habit_likes, dependent: :destroy」（アソシエーション）である「HabitLikesを含んでいること」を確認するためのテストコードを記述
・「has_many :habit_comments, dependent: :destroy」（アソシエーション）である「HabitCommentを含んでいること」を確認するためのテストコードを記述


close #433 