### PR TITLE
HabitCommentモデルに関するテストコード(RSpec)を実装

### DIFF
--- a/spec/models/habit_comment_spec.rb
+++ b/spec/models/habit_comment_spec.rb
@@ -19,4 +19,18 @@ RSpec.describe HabitComment, type: :model do
       expect(habit_comment.errors[:body]).not_to be_empty
     end
   end
+
+  describe 'アソシエーションチェック' do
+    it 'Userに属していること' do
+      user = create(:user)
+      habit_comment = create(:habit_comment, user_id: user.id)
+      expect(habit_comment.user).to eq(user)
+    end
+
+    it 'HabitPostに属していること' do
+      habit_post = create(:habit_post)
+      habit_comment = create(:habit_comment, habit_post_id: habit_post.id)
+      expect(habit_comment.habit_post).to eq(habit_post)
+    end
+  end
 end


### PR DESCRIPTION
**概要**
HabitCommentモデルに関するテストコード(RSpec)を実装

**内容**
・「belongs_to :habit_post」（アソシエーション）である「HabitPostに属していること」を確認するためのテストコードを記述
・「belongs_to :user」（アソシエーション）である「Userに属していること」を確認するためのテストコードを記述